### PR TITLE
Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module example.com
 
-go 1.22.0
+go 1.24.3


### PR DESCRIPTION
This PR updates the Go version in go.mod to 1.24.3, the latest stable release.